### PR TITLE
change $totalSpace >= $params['lastPage'] to accept PageList less than 10 elements

### DIFF
--- a/src/PageList.php
+++ b/src/PageList.php
@@ -215,7 +215,7 @@ class PageList extends Collection
      */
     private function compileNormalList(array $params, $totalSpace)
     {
-        if ($totalSpace > $params['lastPage']) {
+        if ($totalSpace >= $params['lastPage']) {
             $this->compileFullList($params);
         } elseif ($params['current'] <= $totalSpace) {
             $this->compileLeftList($params, $totalSpace);


### PR DESCRIPTION
Update test to display PageList  better when less than 10